### PR TITLE
Fix #17: Enforce max audio upload size

### DIFF
--- a/tests/test_api_e2e.py
+++ b/tests/test_api_e2e.py
@@ -72,3 +72,23 @@ def test_rest_api_session_text_turn_voice_and_tts_routes(
     tts_fetch_response = client.get(f"/api/v1/tts/{audio_id}")
     assert tts_fetch_response.status_code == 200
     assert tts_fetch_response.headers["content-type"] == "audio/wav"
+
+
+def test_rest_api_rejects_oversized_audio_upload(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _configure_test_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("VOICE_TRIAGE_MAX_AUDIO_UPLOAD_BYTES", "128")
+
+    client = TestClient(create_rest_app())
+    create_response = client.post("/api/v1/session")
+    session_id = create_response.json()["session_id"]
+
+    audio_bytes = b"RIFF" + (b"\x00" * 2048)
+    turn_response = client.post(
+        f"/api/v1/session/{session_id}/turn",
+        files={"audio": ("turn.wav", audio_bytes, "audio/wav")},
+    )
+
+    assert turn_response.status_code == 413
+    assert "exceeds max allowed size" in turn_response.text

--- a/voice_triage/http/rest.py
+++ b/voice_triage/http/rest.py
@@ -364,16 +364,37 @@ def create_rest_app() -> FastAPI:
 
 async def _write_turn_audio(audio: UploadFile, settings: Settings, session_id: str) -> Path:
     """write turn audio."""
-    content = await audio.read()
-    if not content:
-        raise HTTPException(status_code=400, detail="Empty audio payload")
-
     audio_dir = settings.data_dir / "tmp_audio"
     audio_dir.mkdir(parents=True, exist_ok=True)
     suffix = ".wav"
     filename = f"web_{session_id}_{uuid.uuid4().hex[:8]}{suffix}"
     wav_path = audio_dir / filename
-    wav_path.write_bytes(content)
+
+    total_bytes = 0
+    has_content = False
+    with wav_path.open("wb") as output:
+        while True:
+            chunk = await audio.read(1024 * 1024)
+            if not chunk:
+                break
+            has_content = True
+            total_bytes += len(chunk)
+            if total_bytes > settings.max_audio_upload_bytes:
+                output.close()
+                wav_path.unlink(missing_ok=True)
+                raise HTTPException(
+                    status_code=413,
+                    detail=(
+                        "Audio payload exceeds max allowed size: "
+                        f"{settings.max_audio_upload_bytes} bytes"
+                    ),
+                )
+            output.write(chunk)
+
+    if not has_content:
+        wav_path.unlink(missing_ok=True)
+        raise HTTPException(status_code=400, detail="Empty audio payload")
+
     return wav_path
 
 

--- a/voice_triage/util/config.py
+++ b/voice_triage/util/config.py
@@ -48,6 +48,7 @@ class Settings:
     piper_default_voice_id: str | None
     web_ssl_certfile: str | None
     web_ssl_keyfile: str | None
+    max_audio_upload_bytes: int
     sample_rate: int = 16_000
     channels: int = 1
 
@@ -158,6 +159,9 @@ def load_settings() -> Settings:
                 project_root=project_root,
                 fallback_to_existing_default=True,
             )
+        ),
+        max_audio_upload_bytes=_env_int(
+            "VOICE_TRIAGE_MAX_AUDIO_UPLOAD_BYTES", default=10 * 1024 * 1024, minimum=1
         ),
     )
 


### PR DESCRIPTION
## Summary
- enforce maximum audio upload size via VOICE_TRIAGE_MAX_AUDIO_UPLOAD_BYTES
- stream upload reads in chunks and stop early on overflow
- return HTTP 413 for oversized uploads
- add E2E test for oversized upload rejection

## Validation
- uv run ruff check .
- uv run mypy voice_triage
- uv run pytest -q
- uv run interrogate --config pyproject.toml voice_triage

Closes #17