### PR TITLE
Fix #20: Add whisper.cpp subprocess timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ uv sync --dev
   -WhisperUseGpu $true `
   -WhisperGpuLayers 60 `
   -WhisperThreads 6 `
+  -WhisperTimeoutSeconds 45 `
   -InferenceBackend "local" `
   -ByoInferenceUrl "" `
   -ByoApiStyle "generic" `
@@ -211,6 +212,7 @@ For faster STT turn latency on NVIDIA GPUs, use a CUDA-enabled `whisper.cpp` bui
 WHISPERCPP_USE_GPU=1
 WHISPERCPP_GPU_LAYERS=60
 WHISPERCPP_THREADS=6
+WHISPERCPP_TIMEOUT_SECONDS=45
 ```
 
 Notes:

--- a/scripts/configure_venv_env.ps1
+++ b/scripts/configure_venv_env.ps1
@@ -4,6 +4,7 @@ param(
     [bool]$WhisperUseGpu = $false,
     [int]$WhisperGpuLayers = 60,
     [int]$WhisperThreads = 0,
+    [double]$WhisperTimeoutSeconds = 45.0,
     [string]$WhisperExtraArgs = "",
     [ValidateSet("local", "byo")]
     [string]$InferenceBackend = "local",
@@ -111,6 +112,7 @@ $content = @(
     "WHISPERCPP_USE_GPU=$([int]$WhisperUseGpu)"
     "WHISPERCPP_GPU_LAYERS=$WhisperGpuLayers"
     "WHISPERCPP_THREADS=$WhisperThreads"
+    "WHISPERCPP_TIMEOUT_SECONDS=$WhisperTimeoutSeconds"
     "WHISPERCPP_EXTRA_ARGS=$WhisperExtraArgs"
     "VOICE_TRIAGE_INFERENCE_BACKEND=$InferenceBackend"
     "VOICE_TRIAGE_BYO_INFERENCE_URL=$ByoInferenceUrl"

--- a/tests/test_whispercpp_client.py
+++ b/tests/test_whispercpp_client.py
@@ -25,10 +25,12 @@ def test_whispercpp_transcribe_parses_stdout(
         capture_output: bool,
         text: bool,
         check: bool,
+        timeout: float,
     ) -> subprocess.CompletedProcess[str]:
         assert capture_output is True
         assert text is True
         assert check is False
+        assert timeout == 45.0
         return subprocess.CompletedProcess(command, 0, stdout="hello from whisper\n", stderr="")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -54,7 +56,9 @@ def test_whispercpp_transcribe_raises_on_nonzero_exit(
         capture_output: bool,
         text: bool,
         check: bool,
+        timeout: float,
     ) -> subprocess.CompletedProcess[str]:
+        assert timeout == 45.0
         return subprocess.CompletedProcess(command, 1, stdout="", stderr="bad model")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -79,6 +83,7 @@ def test_whispercpp_transcribe_adds_cuda_and_runtime_flags(
         capture_output: bool,
         text: bool,
         check: bool,
+        timeout: float,
     ) -> subprocess.CompletedProcess[str]:
         assert "-t" in command
         assert "6" in command
@@ -86,6 +91,7 @@ def test_whispercpp_transcribe_adds_cuda_and_runtime_flags(
         assert "30" in command
         assert "--language" in command
         assert "en" in command
+        assert timeout == 12.5
         return subprocess.CompletedProcess(command, 0, stdout="ok\n", stderr="")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -97,7 +103,34 @@ def test_whispercpp_transcribe_adds_cuda_and_runtime_flags(
         gpu_layers=30,
         threads=6,
         extra_args=("--language", "en"),
+        timeout_seconds=12.5,
     )
     result = client.transcribe(wav_path)
 
     assert result.text == "ok"
+
+
+def test_whispercpp_transcribe_raises_on_timeout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    bin_path = tmp_path / "main"
+    model_path = tmp_path / "ggml-base.en.bin"
+    wav_path = tmp_path / "turn.wav"
+    _touch(bin_path)
+    _touch(model_path)
+    _touch(wav_path)
+
+    def fake_run(
+        command: list[str],
+        capture_output: bool,
+        text: bool,
+        check: bool,
+        timeout: float,
+    ) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(command, timeout)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    client = WhisperCppClient(str(bin_path), str(model_path), timeout_seconds=3.0)
+    with pytest.raises(RuntimeError, match=r"timed out"):
+        client.transcribe(wav_path)

--- a/voice_triage/app/demo.py
+++ b/voice_triage/app/demo.py
@@ -42,6 +42,7 @@ def run_demo() -> int:
         gpu_layers=settings.whispercpp_gpu_layers,
         threads=settings.whispercpp_threads,
         extra_args=settings.whispercpp_extra_args,
+        timeout_seconds=settings.whispercpp_timeout_seconds,
     )
     extractor = HeuristicExtractor()
     rag_service = create_rag_service(settings)

--- a/voice_triage/asr/whispercpp.py
+++ b/voice_triage/asr/whispercpp.py
@@ -32,6 +32,7 @@ class WhisperCppClient:
         gpu_layers: int = 60,
         threads: int | None = None,
         extra_args: tuple[str, ...] = (),
+        timeout_seconds: float = 45.0,
     ) -> None:
         """init  ."""
         self.bin_path = Path(bin_path).expanduser() if bin_path else None
@@ -40,6 +41,7 @@ class WhisperCppClient:
         self.gpu_layers = max(0, gpu_layers)
         self.threads = threads
         self.extra_args = extra_args
+        self.timeout_seconds = max(1.0, timeout_seconds)
 
     def transcribe(self, wav_path: Path) -> AsrResult:
         """Transcribe."""
@@ -65,7 +67,19 @@ class WhisperCppClient:
         if self.extra_args:
             command.extend(self.extra_args)
 
-        process = subprocess.run(command, capture_output=True, text=True, check=False)
+        try:
+            process = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=self.timeout_seconds,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                "whisper.cpp timed out after "
+                f"{self.timeout_seconds:.1f}s while processing audio."
+            ) from exc
         if process.returncode != 0:
             stderr = process.stderr.strip()
             raise RuntimeError(f"whisper.cpp failed with code {process.returncode}: {stderr}")

--- a/voice_triage/http/rest.py
+++ b/voice_triage/http/rest.py
@@ -266,6 +266,7 @@ def initialize_runtime(settings: Settings | None = None) -> ApiRuntime:
         gpu_layers=resolved_settings.whispercpp_gpu_layers,
         threads=resolved_settings.whispercpp_threads,
         extra_args=resolved_settings.whispercpp_extra_args,
+        timeout_seconds=resolved_settings.whispercpp_timeout_seconds,
     )
     tts_client = PiperClient(resolved_settings.piper_bin, resolved_settings.piper_model)
     available_voices, default_voice_id = _discover_piper_voices(

--- a/voice_triage/util/config.py
+++ b/voice_triage/util/config.py
@@ -36,6 +36,7 @@ class Settings:
     whispercpp_gpu_layers: int
     whispercpp_threads: int | None
     whispercpp_extra_args: tuple[str, ...]
+    whispercpp_timeout_seconds: float
     inference_backend: str
     byo_inference_url: str | None
     byo_inference_timeout_seconds: float
@@ -116,6 +117,9 @@ def load_settings() -> Settings:
             shlex.split(whisper_extra_args_raw, posix=os.name != "nt")
             if whisper_extra_args_raw
             else []
+        ),
+        whispercpp_timeout_seconds=_env_float(
+            "WHISPERCPP_TIMEOUT_SECONDS", default=45.0, minimum=1.0
         ),
         inference_backend=os.getenv("VOICE_TRIAGE_INFERENCE_BACKEND", "local"),
         byo_inference_url=os.getenv("VOICE_TRIAGE_BYO_INFERENCE_URL"),


### PR DESCRIPTION
## Summary
- add configurable whisper.cpp subprocess timeout via `WHISPERCPP_TIMEOUT_SECONDS`
- fail fast with clear runtime error when ASR subprocess exceeds timeout
- wire timeout setting through CLI and REST runtime construction
- extend config/bootstrap docs and unit tests for timeout path

## Validation
- uv run ruff check .
- uv run mypy voice_triage
- uv run pytest -q
- uv run interrogate --config pyproject.toml voice_triage

Closes #20
