### PR TITLE
Fix #21: Add Piper subprocess timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,20 +51,22 @@ uv sync --dev
 
 ```powershell
 .\scripts\configure_venv_env.ps1 `
-  -WhisperBin ".venv/tools/whispercpp/whisper-cli.exe" `
+  -WhisperBin ".venv/tools/whispercpp/Release/whisper-cli.exe" `
   -WhisperModel ".venv/tools/whispercpp/models/ggml-base.en.bin" `
   -WhisperUseGpu $true `
   -WhisperGpuLayers 60 `
   -WhisperThreads 6 `
+  -WhisperTimeoutSeconds 45 `
   -InferenceBackend "local" `
   -ByoInferenceUrl "" `
   -ByoApiStyle "generic" `
   -ByoModel "" `
   -ByoApiKey "" `
   -ByoSystemPrompt "" `
-  -PiperBin ".venv/tools/piper/piper.exe" `
+  -PiperBin ".venv/Scripts/piper.exe" `
   -PiperModel ".venv/tools/piper/models/en_GB-alba-medium.onnx" `
   -PiperDefaultVoiceId "en_GB-alba-medium" `
+  -PiperTimeoutSeconds 30 `
   -WebHost "0.0.0.0" `
   -WebPort 8443 `
   -SslCertFile ".venv/certs/dev-cert.pem" `

--- a/scripts/configure_venv_env.ps1
+++ b/scripts/configure_venv_env.ps1
@@ -17,6 +17,7 @@ param(
     [string]$PiperBin = "",
     [string]$PiperModel = "",
     [string]$PiperDefaultVoiceId = "en_GB-alba-medium",
+    [double]$PiperTimeoutSeconds = 30.0,
     [string]$SslCertFile = "",
     [string]$SslKeyFile = "",
     [string]$WebHost = "0.0.0.0",
@@ -122,6 +123,7 @@ $content = @(
     "PIPER_BIN=$PiperBin"
     "PIPER_MODEL=$PiperModel"
     "PIPER_DEFAULT_VOICE_ID=$PiperDefaultVoiceId"
+    "PIPER_TIMEOUT_SECONDS=$PiperTimeoutSeconds"
     "VOICE_TRIAGE_SSL_CERTFILE=$SslCertFile"
     "VOICE_TRIAGE_SSL_KEYFILE=$SslKeyFile"
     "VOICE_TRIAGE_WEB_HOST=$WebHost"

--- a/tests/test_piper_client.py
+++ b/tests/test_piper_client.py
@@ -23,12 +23,14 @@ def test_piper_synthesize_to_wav_success(monkeypatch: pytest.MonkeyPatch, tmp_pa
         text: bool,
         capture_output: bool,
         check: bool,
+        timeout: float,
     ) -> subprocess.CompletedProcess[str]:
         assert "--model" in command
         assert "--output_file" in command
         assert text is True
         assert capture_output is True
         assert check is False
+        assert timeout == 30.0
         assert "hello there" in input
         output_index = command.index("--output_file") + 1
         Path(command[output_index]).write_bytes(b"RIFF....WAVE")
@@ -57,11 +59,36 @@ def test_piper_synthesize_to_wav_nonzero_exit(
         text: bool,
         capture_output: bool,
         check: bool,
+        timeout: float,
     ) -> subprocess.CompletedProcess[str]:
+        assert timeout == 30.0
         return subprocess.CompletedProcess(command, 1, stdout="", stderr="bad voice")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
     client = PiperClient(str(bin_path), str(model_path))
     with pytest.raises(RuntimeError, match="Piper failed"):
+        client.synthesize_to_wav("hello there", tmp_path / "speech.wav")
+
+
+def test_piper_synthesize_to_wav_timeout(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    bin_path = tmp_path / "piper"
+    model_path = tmp_path / "voice.onnx"
+    _touch(bin_path)
+    _touch(model_path)
+
+    def fake_run(
+        command: list[str],
+        input: str,
+        text: bool,
+        capture_output: bool,
+        check: bool,
+        timeout: float,
+    ) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(command, timeout)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    client = PiperClient(str(bin_path), str(model_path), timeout_seconds=4.0)
+    with pytest.raises(RuntimeError, match="timed out"):
         client.synthesize_to_wav("hello there", tmp_path / "speech.wav")

--- a/voice_triage/http/rest.py
+++ b/voice_triage/http/rest.py
@@ -267,7 +267,11 @@ def initialize_runtime(settings: Settings | None = None) -> ApiRuntime:
         threads=resolved_settings.whispercpp_threads,
         extra_args=resolved_settings.whispercpp_extra_args,
     )
-    tts_client = PiperClient(resolved_settings.piper_bin, resolved_settings.piper_model)
+    tts_client = PiperClient(
+        resolved_settings.piper_bin,
+        resolved_settings.piper_model,
+        timeout_seconds=resolved_settings.piper_timeout_seconds,
+    )
     available_voices, default_voice_id = _discover_piper_voices(
         tts_client.model_path, resolved_settings.piper_default_voice_id
     )

--- a/voice_triage/tts/piper.py
+++ b/voice_triage/tts/piper.py
@@ -14,10 +14,13 @@ class PiperUnavailable(RuntimeError):
 class PiperClient:
     """Subprocess wrapper around Piper CLI TTS."""
 
-    def __init__(self, bin_path: str | None, model_path: str | None) -> None:
+    def __init__(
+        self, bin_path: str | None, model_path: str | None, timeout_seconds: float = 30.0
+    ) -> None:
         """init  ."""
         self.bin_path = bin_path
         self.model_path = Path(model_path).expanduser() if model_path else None
+        self.timeout_seconds = max(1.0, timeout_seconds)
 
     def ensure_ready(self, model_path: Path | None = None) -> None:
         """Ensure ready."""
@@ -51,13 +54,19 @@ class PiperClient:
             str(output_path),
         ]
 
-        process = subprocess.run(
-            command,
-            input=text,
-            text=True,
-            capture_output=True,
-            check=False,
-        )
+        try:
+            process = subprocess.run(
+                command,
+                input=text,
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=self.timeout_seconds,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"Piper timed out after {self.timeout_seconds:.1f}s while synthesizing audio."
+            ) from exc
         if process.returncode != 0:
             raise RuntimeError(
                 f"Piper failed with code {process.returncode}: {process.stderr.strip()}"

--- a/voice_triage/util/config.py
+++ b/voice_triage/util/config.py
@@ -46,6 +46,7 @@ class Settings:
     piper_bin: str | None
     piper_model: str | None
     piper_default_voice_id: str | None
+    piper_timeout_seconds: float
     web_ssl_certfile: str | None
     web_ssl_keyfile: str | None
     sample_rate: int = 16_000
@@ -143,6 +144,7 @@ def load_settings() -> Settings:
             )
         ),
         piper_default_voice_id=os.getenv("PIPER_DEFAULT_VOICE_ID", "en_GB-alba-medium"),
+        piper_timeout_seconds=_env_float("PIPER_TIMEOUT_SECONDS", default=30.0, minimum=1.0),
         web_ssl_certfile=str(
             _resolve_config_path(
                 raw_value=os.getenv("VOICE_TRIAGE_SSL_CERTFILE"),


### PR DESCRIPTION
## Summary
- add configurable Piper subprocess timeout via `PIPER_TIMEOUT_SECONDS`
- surface clear timeout errors when TTS hangs
- wire timeout setting through REST runtime initialization
- update setup docs and unit coverage for timeout behavior

## Validation
- uv run ruff check .
- uv run mypy voice_triage
- uv run pytest -q
- uv run interrogate --config pyproject.toml voice_triage

Closes #21
