### PR TITLE
Fix #22: Add temp audio/TTS cleanup

### DIFF
--- a/tests/test_temp_cleanup.py
+++ b/tests/test_temp_cleanup.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from voice_triage.http.rest import _cleanup_temp_directory
+
+
+def _touch_file(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("x", encoding="utf-8")
+
+
+def test_cleanup_temp_directory_removes_old_files(tmp_path: Path) -> None:
+    temp_dir = tmp_path / "tmp_audio"
+    old_file = temp_dir / "old.wav"
+    new_file = temp_dir / "new.wav"
+    _touch_file(old_file)
+    _touch_file(new_file)
+
+    old_epoch = 1_577_836_800  # 2020-01-01T00:00:00Z
+    new_epoch = 2_524_608_000  # 2050-01-01T00:00:00Z
+    os.utime(old_file, (old_epoch, old_epoch))
+    os.utime(new_file, (new_epoch, new_epoch))
+
+    _cleanup_temp_directory(temp_dir, retention_seconds=60 * 60, max_count=10)
+
+    assert not old_file.exists()
+    assert new_file.exists()
+
+
+def test_cleanup_temp_directory_enforces_max_count(tmp_path: Path) -> None:
+    temp_dir = tmp_path / "tmp_tts"
+    files = []
+    for idx in range(5):
+        file_path = temp_dir / f"tts_{idx}.wav"
+        _touch_file(file_path)
+        timestamp = 2_000_000_000 + idx
+        os.utime(file_path, (timestamp, timestamp))
+        files.append(file_path)
+
+    _cleanup_temp_directory(temp_dir, retention_seconds=60 * 60 * 24 * 365, max_count=2)
+
+    remaining = sorted(temp_dir.glob("*.wav"))
+    assert len(remaining) == 2
+    assert remaining == [files[3], files[4]]

--- a/voice_triage/http/rest.py
+++ b/voice_triage/http/rest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 import uuid
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -371,6 +372,11 @@ async def _write_turn_audio(audio: UploadFile, settings: Settings, session_id: s
     """write turn audio."""
     audio_dir = settings.data_dir / "tmp_audio"
     audio_dir.mkdir(parents=True, exist_ok=True)
+    _cleanup_temp_directory(
+        audio_dir,
+        retention_seconds=settings.temp_file_retention_seconds,
+        max_count=settings.temp_file_max_count,
+    )
     suffix = ".wav"
     filename = f"web_{session_id}_{uuid.uuid4().hex[:8]}{suffix}"
     wav_path = audio_dir / filename
@@ -413,10 +419,39 @@ def _synthesize_tts(
     """synthesize tts."""
     tts_dir = settings.data_dir / "tmp_tts"
     tts_dir.mkdir(parents=True, exist_ok=True)
+    _cleanup_temp_directory(
+        tts_dir,
+        retention_seconds=settings.temp_file_retention_seconds,
+        max_count=settings.temp_file_max_count,
+    )
     audio_id = f"{session_id}_{uuid.uuid4().hex[:8]}"
     output_wav = tts_dir / f"{audio_id}.wav"
     client.synthesize_to_wav(text=text, output_path=output_wav, model_path=model_path)
     return audio_id
+
+
+def _cleanup_temp_directory(directory: Path, retention_seconds: int, max_count: int) -> None:
+    """Delete stale and excess files in a temp directory."""
+    if not directory.exists():
+        return
+
+    cutoff_epoch = time.time() - retention_seconds
+    for candidate in directory.glob("*"):
+        if not candidate.is_file():
+            continue
+        try:
+            if candidate.stat().st_mtime < cutoff_epoch:
+                candidate.unlink(missing_ok=True)
+        except OSError:
+            continue
+
+    files = [item for item in directory.glob("*") if item.is_file()]
+    files.sort(key=lambda item: item.stat().st_mtime, reverse=True)
+    for stale in files[max_count:]:
+        try:
+            stale.unlink(missing_ok=True)
+        except OSError:
+            continue
 
 
 def _discover_piper_voices(

--- a/voice_triage/util/config.py
+++ b/voice_triage/util/config.py
@@ -52,6 +52,8 @@ class Settings:
     web_ssl_certfile: str | None
     web_ssl_keyfile: str | None
     max_audio_upload_bytes: int
+    temp_file_retention_seconds: int
+    temp_file_max_count: int
     sample_rate: int = 16_000
     channels: int = 1
 
@@ -171,6 +173,10 @@ def load_settings() -> Settings:
         max_audio_upload_bytes=_env_int(
             "VOICE_TRIAGE_MAX_AUDIO_UPLOAD_BYTES", default=10 * 1024 * 1024, minimum=1
         ),
+        temp_file_retention_seconds=_env_int(
+            "VOICE_TRIAGE_TEMP_FILE_RETENTION_SECONDS", default=4 * 60 * 60, minimum=60
+        ),
+        temp_file_max_count=_env_int("VOICE_TRIAGE_TEMP_FILE_MAX_COUNT", default=500, minimum=10),
     )
 
 


### PR DESCRIPTION
## Summary
- add opportunistic temp-file cleanup for `data/tmp_audio` and `data/tmp_tts`
- enforce both time-based retention and max-file-count caps
- make cleanup thresholds configurable with env settings
- add tests for stale-file removal and count-based pruning

## Validation
- uv run ruff check .
- uv run mypy voice_triage
- uv run pytest -q
- uv run interrogate --config pyproject.toml voice_triage

Closes #22
