### PR TITLE
Fix #24: Improve move-home address validation

### DIFF
--- a/tests/test_conversation_engine.py
+++ b/tests/test_conversation_engine.py
@@ -126,3 +126,25 @@ def test_move_flow_accepts_natural_language_date() -> None:
 
     assert result.stage == ConversationStage.CONFIRM
     assert result.outcome["captured_data"]["move_date"] == "2026-04-04"
+
+
+def test_move_flow_rejects_non_address_text_for_current_address() -> None:
+    engine = ConversationEngine(extractor=HeuristicExtractor(), rag_service=FakeRagService())
+    session_id, _ = engine.create_session()
+
+    engine.process_turn(session_id=session_id, transcript="I'm moving house")
+    result = engine.process_turn(session_id=session_id, transcript="not sure")
+
+    assert result.stage == ConversationStage.ASK_CURRENT_ADDRESS
+    assert "current address" in result.response_text.lower()
+
+
+def test_move_flow_rejects_address_without_house_number() -> None:
+    engine = ConversationEngine(extractor=HeuristicExtractor(), rag_service=FakeRagService())
+    session_id, _ = engine.create_session()
+
+    engine.process_turn(session_id=session_id, transcript="I'm moving house")
+    result = engine.process_turn(session_id=session_id, transcript="Cheltenham Place")
+
+    assert result.stage == ConversationStage.ASK_CURRENT_ADDRESS
+    assert "current address" in result.response_text.lower()

--- a/voice_triage/app/conversation.py
+++ b/voice_triage/app/conversation.py
@@ -478,22 +478,23 @@ class ConversationEngine:
         if len(normalized) < 8:
             return None
 
-        address_markers = (
-            " road",
-            " street",
-            " avenue",
-            " lane",
-            " drive",
-            " close",
-            " court",
-            " place",
-            ",",
-        )
         has_number = any(char.isdigit() for char in normalized)
-        has_marker = any(marker in normalized.lower() for marker in address_markers)
+        has_alpha = any(char.isalpha() for char in normalized)
         has_postcode = extraction.postcode is not None
+        lowered = normalized.lower()
+        invalid_phrases = {
+            "not sure",
+            "no idea",
+            "unknown",
+            "none",
+            "n a",
+            "na",
+            "idk",
+        }
+        if lowered in invalid_phrases:
+            return None
 
-        if not (has_number or has_marker or has_postcode):
+        if not ((has_alpha and has_number) or has_postcode):
             return None
         return normalized
 


### PR DESCRIPTION
## Summary
- tighten move-home address candidate acceptance rules
- require meaningful address signal (letters + number or postcode)
- reject low-signal placeholder responses (e.g. "not sure", "unknown")
- add conversation tests for rejected invalid address inputs

## Validation
- uv run ruff check .
- uv run mypy voice_triage
- uv run pytest -q
- uv run interrogate --config pyproject.toml voice_triage

Closes #24
