### PR TITLE
Fix #25: Improve two-digit year normalization

### DIFF
--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -14,6 +14,18 @@ def test_extractor_parses_numeric_day_first_date() -> None:
     assert result.move_date == "2026-04-04"
 
 
+def test_extractor_parses_two_digit_year_in_current_century_window() -> None:
+    extractor = HeuristicExtractor()
+    result = extractor.extract("Move date: 04/04/26")
+    assert result.move_date == "2026-04-04"
+
+
+def test_extractor_parses_two_digit_year_in_previous_century_when_far_future() -> None:
+    extractor = HeuristicExtractor()
+    result = extractor.extract("Move date: 04/04/99")
+    assert result.move_date == "1999-04-04"
+
+
 def test_extractor_keeps_garden_waste_as_rag_intent() -> None:
     extractor = HeuristicExtractor()
     result = extractor.extract("How do I order a garden waste bin?")

--- a/voice_triage/nlu/extractor.py
+++ b/voice_triage/nlu/extractor.py
@@ -161,7 +161,11 @@ class HeuristicExtractor:
     def _normalize_year(year: int) -> int:
         """normalize year."""
         if year < 100:
-            return 2000 + year
+            current_year = datetime.now().year
+            normalized = 2000 + year
+            if normalized > current_year + 20:
+                normalized -= 100
+            return normalized
         return year
 
     @staticmethod


### PR DESCRIPTION
## Summary
- replace fixed 2000s two-digit year expansion with sliding-window normalization
- map far-future two-digit years into previous century when appropriate
- add extractor tests for `26` -> `2026` and `99` -> `1999`

## Validation
- uv run ruff check .
- uv run mypy voice_triage
- uv run pytest -q
- uv run interrogate --config pyproject.toml voice_triage

Closes #25
