### PR TITLE
Fix #26: Validate BYO inference URL

### DIFF
--- a/docs/BYO_INFERENCE_REFERENCE.md
+++ b/docs/BYO_INFERENCE_REFERENCE.md
@@ -64,6 +64,9 @@ VOICE_TRIAGE_BYO_API_KEY=
 VOICE_TRIAGE_BYO_SYSTEM_PROMPT=You are a concise UK council support assistant.
 ```
 
+Validation note:
+- `VOICE_TRIAGE_BYO_INFERENCE_URL` must be an `http://` or `https://` URL with a host.
+
 Request (`POST`):
 
 ```json

--- a/tests/test_config_paths.py
+++ b/tests/test_config_paths.py
@@ -1,11 +1,14 @@
 import os
 from pathlib import Path
 
+import pytest
+
 from voice_triage.util.config import (
     _default_piper_bin,
     _default_whisper_bin,
     _resolve_config_path,
     _should_override_stale_path_env,
+    _validate_byo_inference_url,
 )
 
 
@@ -117,3 +120,18 @@ def test_default_whisper_bin_prefers_release_or_build_layout(tmp_path: Path) -> 
     selected = _default_whisper_bin(venv_dir)
 
     assert selected == preferred
+
+
+def test_validate_byo_inference_url_allows_http_and_https() -> None:
+    assert _validate_byo_inference_url("http://127.0.0.1:11434/v1/chat/completions")
+    assert _validate_byo_inference_url("https://example.com/infer")
+
+
+def test_validate_byo_inference_url_rejects_non_http_scheme() -> None:
+    with pytest.raises(ValueError, match="http:// or https://"):
+        _validate_byo_inference_url("file:///tmp/infer")
+
+
+def test_validate_byo_inference_url_rejects_missing_host() -> None:
+    with pytest.raises(ValueError, match="include a host"):
+        _validate_byo_inference_url("http:///infer")

--- a/voice_triage/util/config.py
+++ b/voice_triage/util/config.py
@@ -6,6 +6,7 @@ import os
 import shlex
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import urlsplit
 
 _PATH_LIKE_ENV_KEYS = {
     "VOICE_TRIAGE_DB",
@@ -78,6 +79,7 @@ def load_settings() -> Settings:
     ssl_key_default = venv_dir / "certs" / "dev-key.pem"
     whisper_threads_raw = os.getenv("WHISPERCPP_THREADS", "").strip()
     whisper_extra_args_raw = os.getenv("WHISPERCPP_EXTRA_ARGS", "").strip()
+    byo_inference_url = _validate_byo_inference_url(os.getenv("VOICE_TRIAGE_BYO_INFERENCE_URL"))
 
     return Settings(
         project_root=project_root,
@@ -118,7 +120,7 @@ def load_settings() -> Settings:
             else []
         ),
         inference_backend=os.getenv("VOICE_TRIAGE_INFERENCE_BACKEND", "local"),
-        byo_inference_url=os.getenv("VOICE_TRIAGE_BYO_INFERENCE_URL"),
+        byo_inference_url=byo_inference_url,
         byo_inference_timeout_seconds=_env_float(
             "VOICE_TRIAGE_BYO_INFERENCE_TIMEOUT_SECONDS", default=12.0, minimum=0.1
         ),
@@ -229,6 +231,22 @@ def _resolve_path(path_value: Path, project_root: Path) -> Path:
     if expanded.is_absolute():
         return expanded.resolve(strict=False)
     return (project_root / expanded).resolve(strict=False)
+
+
+def _validate_byo_inference_url(raw_url: str | None) -> str | None:
+    """Validate BYO inference URL format (scheme and host) when configured."""
+    if raw_url is None:
+        return None
+    cleaned = raw_url.strip()
+    if not cleaned:
+        return None
+
+    parsed = urlsplit(cleaned)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError("VOICE_TRIAGE_BYO_INFERENCE_URL must use http:// or https:// scheme.")
+    if not parsed.netloc:
+        raise ValueError("VOICE_TRIAGE_BYO_INFERENCE_URL must include a host.")
+    return cleaned
 
 
 def _default_whisper_bin(venv_dir: Path) -> Path:


### PR DESCRIPTION
## Summary
- validate `VOICE_TRIAGE_BYO_INFERENCE_URL` at config load time
- require `http://` or `https://` scheme and a non-empty host
- fail fast on invalid BYO URL values
- add unit tests for valid/invalid URL cases and update BYO docs

## Validation
- uv run ruff check .
- uv run mypy voice_triage
- uv run pytest -q
- uv run interrogate --config pyproject.toml voice_triage

Closes #26
