### PR TITLE
Fix #28: Add transcript validation constraints

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -117,7 +117,7 @@ Returns:
 
 Common status codes:
 - `404` unknown session or voice id
-- `422` empty transcript
+- `422` invalid transcript (empty, too long, or missing alphanumeric content)
 - `503` ASR unavailable (`whisper.cpp` missing/unconfigured)
 - `500` internal subprocess/runtime failure
 

--- a/tests/test_api_e2e.py
+++ b/tests/test_api_e2e.py
@@ -92,3 +92,41 @@ def test_rest_api_rejects_oversized_audio_upload(
 
     assert turn_response.status_code == 413
     assert "exceeds max allowed size" in turn_response.text
+
+
+def test_rest_api_rejects_too_long_transcript(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _configure_test_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("VOICE_TRIAGE_MAX_TRANSCRIPT_CHARS", "32")
+
+    client = TestClient(create_rest_app())
+    create_response = client.post("/api/v1/session")
+    session_id = create_response.json()["session_id"]
+
+    long_text = "a" * 100
+    turn_response = client.post(
+        f"/api/v1/session/{session_id}/turn/text",
+        json={"transcript": long_text},
+    )
+
+    assert turn_response.status_code == 422
+    assert "exceeds max length" in turn_response.text
+
+
+def test_rest_api_rejects_non_alphanumeric_transcript(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _configure_test_env(monkeypatch, tmp_path)
+
+    client = TestClient(create_rest_app())
+    create_response = client.post("/api/v1/session")
+    session_id = create_response.json()["session_id"]
+
+    turn_response = client.post(
+        f"/api/v1/session/{session_id}/turn/text",
+        json={"transcript": ".... !!! ???"},
+    )
+
+    assert turn_response.status_code == 422
+    assert "alphanumeric" in turn_response.text

--- a/voice_triage/http/rest.py
+++ b/voice_triage/http/rest.py
@@ -166,9 +166,19 @@ class TriageApi:
         if session_id not in self.runtime.engine.sessions:
             raise HTTPException(status_code=404, detail="Unknown session id")
 
-        cleaned = transcript.strip()
+        cleaned = " ".join(transcript.split()).strip()
         if not cleaned:
             raise HTTPException(status_code=422, detail="Empty transcript text")
+        if len(cleaned) > self.runtime.settings.max_transcript_chars:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "Transcript exceeds max length "
+                    f"({self.runtime.settings.max_transcript_chars} characters)"
+                ),
+            )
+        if not any(character.isalnum() for character in cleaned):
+            raise HTTPException(status_code=422, detail="Transcript must include alphanumeric text")
 
         turn_result = self.runtime.engine.process_turn(session_id=session_id, transcript=cleaned)
 

--- a/voice_triage/util/config.py
+++ b/voice_triage/util/config.py
@@ -54,6 +54,7 @@ class Settings:
     max_audio_upload_bytes: int
     temp_file_retention_seconds: int
     temp_file_max_count: int
+    max_transcript_chars: int
     sample_rate: int = 16_000
     channels: int = 1
 
@@ -177,6 +178,7 @@ def load_settings() -> Settings:
             "VOICE_TRIAGE_TEMP_FILE_RETENTION_SECONDS", default=4 * 60 * 60, minimum=60
         ),
         temp_file_max_count=_env_int("VOICE_TRIAGE_TEMP_FILE_MAX_COUNT", default=500, minimum=10),
+        max_transcript_chars=_env_int("VOICE_TRIAGE_MAX_TRANSCRIPT_CHARS", default=4000, minimum=1),
     )
 
 


### PR DESCRIPTION
## Summary
- normalize and validate transcript text before orchestration
- enforce configurable max transcript length via `VOICE_TRIAGE_MAX_TRANSCRIPT_CHARS`
- reject transcript payloads without alphanumeric content
- add API E2E tests for invalid transcript cases

## Validation
- uv run ruff check .
- uv run mypy voice_triage
- uv run pytest -q
- uv run interrogate --config pyproject.toml voice_triage

Closes #28
