### PR TITLE
Fix #29: Make VAD params configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Useful endpoints:
 - `POST /api/v1/session/{session_id}/turn` (audio upload)
 - `POST /api/v1/session/{session_id}/turn/text` (pre-transcribed text)
 - `GET /api/v1/voices`
+- `GET /api/v1/config` (client runtime config, including VAD tuning)
 - `POST /api/v1/session/{session_id}/voice`
 - `GET /api/v1/tts/{audio_id}`
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -47,6 +47,12 @@ Response:
 }
 ```
 
+## Client Config
+
+`GET /api/v1/config`
+
+Returns frontend runtime tuning values (including VAD thresholds and turn timing).
+
 ## Select Voice
 
 `POST /api/v1/session/{session_id}/voice`

--- a/scripts/configure_venv_env.ps1
+++ b/scripts/configure_venv_env.ps1
@@ -21,6 +21,13 @@ param(
     [double]$PiperTimeoutSeconds = 30.0,
     [string]$SslCertFile = "",
     [string]$SslKeyFile = "",
+    [double]$WebVadRmsThreshold = 0.006,
+    [double]$WebVadAbsMinRms = 0.0045,
+    [double]$WebVadSpeechFactor = 2.2,
+    [double]$WebVadNoiseAlpha = 0.96,
+    [int]$WebVadMinSpeechMs = 180,
+    [int]$WebVadSilenceHoldMs = 1000,
+    [int]$WebVadMaxTurnMs = 30000,
     [string]$WebHost = "0.0.0.0",
     [int]$WebPort = 8443
 )
@@ -128,6 +135,13 @@ $content = @(
     "PIPER_TIMEOUT_SECONDS=$PiperTimeoutSeconds"
     "VOICE_TRIAGE_SSL_CERTFILE=$SslCertFile"
     "VOICE_TRIAGE_SSL_KEYFILE=$SslKeyFile"
+    "VOICE_TRIAGE_WEB_VAD_RMS_THRESHOLD=$WebVadRmsThreshold"
+    "VOICE_TRIAGE_WEB_VAD_ABS_MIN_RMS=$WebVadAbsMinRms"
+    "VOICE_TRIAGE_WEB_VAD_SPEECH_FACTOR=$WebVadSpeechFactor"
+    "VOICE_TRIAGE_WEB_VAD_NOISE_ALPHA=$WebVadNoiseAlpha"
+    "VOICE_TRIAGE_WEB_VAD_MIN_SPEECH_MS=$WebVadMinSpeechMs"
+    "VOICE_TRIAGE_WEB_VAD_SILENCE_HOLD_MS=$WebVadSilenceHoldMs"
+    "VOICE_TRIAGE_WEB_VAD_MAX_TURN_MS=$WebVadMaxTurnMs"
     "VOICE_TRIAGE_WEB_HOST=$WebHost"
     "VOICE_TRIAGE_WEB_PORT=$WebPort"
 )

--- a/tests/test_api_e2e.py
+++ b/tests/test_api_e2e.py
@@ -36,6 +36,12 @@ def test_rest_api_session_text_turn_voice_and_tts_routes(
     data_dir = _configure_test_env(monkeypatch, tmp_path)
     client = TestClient(create_rest_app())
 
+    config_response = client.get("/api/v1/config")
+    assert config_response.status_code == 200
+    config_payload = config_response.json()
+    assert config_payload["vad_rms_threshold"] > 0
+    assert config_payload["vad_max_turn_ms"] >= 1000
+
     create_response = client.post("/api/v1/session")
     assert create_response.status_code == 200
     create_payload = create_response.json()

--- a/voice_triage/http/rest.py
+++ b/voice_triage/http/rest.py
@@ -68,6 +68,18 @@ class TextTurnRequest(BaseModel):
     transcript: str
 
 
+class ClientConfigResponse(BaseModel):
+    """Clientconfigresponse."""
+
+    vad_rms_threshold: float
+    vad_abs_min_rms: float
+    vad_speech_factor: float
+    vad_noise_alpha: float
+    vad_min_speech_ms: int
+    vad_silence_hold_ms: int
+    vad_max_turn_ms: int
+
+
 class TurnResponse(BaseModel):
     """Turnresponse."""
 
@@ -159,6 +171,19 @@ class TriageApi:
             session_id=session_id,
             voice_id=voice_id,
             label=_voice_label_from_path(selected_path),
+        )
+
+    def get_client_config(self) -> ClientConfigResponse:
+        """Return client-side runtime configuration values."""
+        settings = self.runtime.settings
+        return ClientConfigResponse(
+            vad_rms_threshold=settings.web_vad_rms_threshold,
+            vad_abs_min_rms=settings.web_vad_abs_min_rms,
+            vad_speech_factor=settings.web_vad_speech_factor,
+            vad_noise_alpha=settings.web_vad_noise_alpha,
+            vad_min_speech_ms=settings.web_vad_min_speech_ms,
+            vad_silence_hold_ms=settings.web_vad_silence_hold_ms,
+            vad_max_turn_ms=settings.web_vad_max_turn_ms,
         )
 
     def process_transcript_turn(self, session_id: str, transcript: str) -> TurnResponse:
@@ -322,6 +347,11 @@ def create_api_router(
     def list_voices() -> VoiceListResponse:
         """List voices."""
         return api.list_voices()
+
+    @router.get("/config", response_model=ClientConfigResponse, include_in_schema=include_in_schema)
+    def get_client_config() -> ClientConfigResponse:
+        """Get client config."""
+        return api.get_client_config()
 
     @router.post(
         "/session/{session_id}/voice",

--- a/voice_triage/util/config.py
+++ b/voice_triage/util/config.py
@@ -55,6 +55,13 @@ class Settings:
     temp_file_retention_seconds: int
     temp_file_max_count: int
     max_transcript_chars: int
+    web_vad_rms_threshold: float
+    web_vad_abs_min_rms: float
+    web_vad_speech_factor: float
+    web_vad_noise_alpha: float
+    web_vad_min_speech_ms: int
+    web_vad_silence_hold_ms: int
+    web_vad_max_turn_ms: int
     sample_rate: int = 16_000
     channels: int = 1
 
@@ -179,6 +186,13 @@ def load_settings() -> Settings:
         ),
         temp_file_max_count=_env_int("VOICE_TRIAGE_TEMP_FILE_MAX_COUNT", default=500, minimum=10),
         max_transcript_chars=_env_int("VOICE_TRIAGE_MAX_TRANSCRIPT_CHARS", default=4000, minimum=1),
+        web_vad_rms_threshold=_env_float("VOICE_TRIAGE_WEB_VAD_RMS_THRESHOLD", 0.006, 0.0001),
+        web_vad_abs_min_rms=_env_float("VOICE_TRIAGE_WEB_VAD_ABS_MIN_RMS", 0.0045, 0.0001),
+        web_vad_speech_factor=_env_float("VOICE_TRIAGE_WEB_VAD_SPEECH_FACTOR", 2.2, 1.0),
+        web_vad_noise_alpha=_env_float("VOICE_TRIAGE_WEB_VAD_NOISE_ALPHA", 0.96, 0.5),
+        web_vad_min_speech_ms=_env_int("VOICE_TRIAGE_WEB_VAD_MIN_SPEECH_MS", 180, 50),
+        web_vad_silence_hold_ms=_env_int("VOICE_TRIAGE_WEB_VAD_SILENCE_HOLD_MS", 1000, 100),
+        web_vad_max_turn_ms=_env_int("VOICE_TRIAGE_WEB_VAD_MAX_TURN_MS", 30000, 1000),
     )
 
 

--- a/voice_triage/web/static/app.js
+++ b/voice_triage/web/static/app.js
@@ -16,19 +16,22 @@ const state = {
   lastSpeechAtMs: null,
   recordingStartedAtMs: null,
   noiseFloorRms: 0.002,
+  vad: null,
   continuousMode: false,
   ttsAudio: null,
   selectedVoiceId: null,
 };
 const API_BASE = "/api/v1";
-
-const VAD_RMS_THRESHOLD = 0.006;
-const VAD_MIN_SPEECH_MS = 180;
-const VAD_SILENCE_HOLD_MS = 1000;
-const VAD_MAX_TURN_MS = 30000;
-const VAD_ABS_MIN_RMS = 0.0045;
-const VAD_SPEECH_FACTOR = 2.2;
-const VAD_NOISE_ALPHA = 0.96;
+const DEFAULT_VAD_CONFIG = {
+  vad_rms_threshold: 0.006,
+  vad_abs_min_rms: 0.0045,
+  vad_speech_factor: 2.2,
+  vad_noise_alpha: 0.96,
+  vad_min_speech_ms: 180,
+  vad_silence_hold_ms: 1000,
+  vad_max_turn_ms: 30000,
+};
+state.vad = { ...DEFAULT_VAD_CONFIG };
 
 const chatLog = document.getElementById("chatLog");
 const statusText = document.getElementById("statusText");
@@ -113,6 +116,18 @@ async function loadVoices() {
   state.selectedVoiceId = payload.default_voice_id || payload.voices[0].voice_id;
   voiceSelect.value = state.selectedVoiceId;
   voiceSelect.disabled = false;
+}
+
+async function loadClientConfig() {
+  const response = await fetch(`${API_BASE}/config`);
+  if (!response.ok) {
+    throw new Error(`Failed to load client config (${response.status})`);
+  }
+  const payload = await response.json();
+  state.vad = {
+    ...DEFAULT_VAD_CONFIG,
+    ...payload,
+  };
 }
 
 async function setSessionVoice(voiceId, options = {}) {
@@ -267,9 +282,9 @@ function handleVadFrame(channelData, sampleRate) {
   const frameDurationMs = (channelData.length / Math.max(1, sampleRate)) * 1000;
   const rms = computeRms(channelData);
   const adaptiveThreshold = Math.max(
-    VAD_ABS_MIN_RMS,
-    VAD_RMS_THRESHOLD,
-    state.noiseFloorRms * VAD_SPEECH_FACTOR,
+    state.vad.vad_abs_min_rms,
+    state.vad.vad_rms_threshold,
+    state.noiseFloorRms * state.vad.vad_speech_factor,
   );
   const isSpeechFrame = rms >= adaptiveThreshold;
 
@@ -278,16 +293,17 @@ function handleVadFrame(channelData, sampleRate) {
     if (state.speechStartedAtMs === null) {
       state.speechStartedAtMs = nowMs;
     }
-    if (!state.speechDetected && nowMs - state.speechStartedAtMs >= VAD_MIN_SPEECH_MS) {
+    if (!state.speechDetected && nowMs - state.speechStartedAtMs >= state.vad.vad_min_speech_ms) {
       state.speechDetected = true;
       setStatus("Listening...");
     }
   } else if (!state.speechDetected) {
-    state.noiseFloorRms = VAD_NOISE_ALPHA * state.noiseFloorRms + (1 - VAD_NOISE_ALPHA) * rms;
+    state.noiseFloorRms =
+      state.vad.vad_noise_alpha * state.noiseFloorRms + (1 - state.vad.vad_noise_alpha) * rms;
     state.speechStartedAtMs = null;
     if (
       state.recordingStartedAtMs !== null &&
-      nowMs - state.recordingStartedAtMs > VAD_MAX_TURN_MS
+      nowMs - state.recordingStartedAtMs > state.vad.vad_max_turn_ms
     ) {
       setStatus("Processing turn...");
       requestStopRecording("max_turn_no_speech");
@@ -298,7 +314,7 @@ function handleVadFrame(channelData, sampleRate) {
   if (
     state.speechDetected &&
     state.lastSpeechAtMs !== null &&
-    nowMs - state.lastSpeechAtMs >= VAD_SILENCE_HOLD_MS
+    nowMs - state.lastSpeechAtMs >= state.vad.vad_silence_hold_ms
   ) {
     setStatus("Silence detected. Processing...");
     requestStopRecording("vad_silence");
@@ -308,7 +324,7 @@ function handleVadFrame(channelData, sampleRate) {
   if (
     state.speechDetected &&
     state.recordingStartedAtMs !== null &&
-    nowMs - state.recordingStartedAtMs + frameDurationMs >= VAD_MAX_TURN_MS
+    nowMs - state.recordingStartedAtMs + frameDurationMs >= state.vad.vad_max_turn_ms
   ) {
     setStatus("Processing long turn...");
     requestStopRecording("max_turn");
@@ -554,6 +570,7 @@ voiceSelect.addEventListener("change", async () => {
 
 async function initializeUi() {
   try {
+    await loadClientConfig();
     await loadVoices();
     updateCapturedDataBox(null);
     setStatus("Ready. Click Start Listening.");


### PR DESCRIPTION
## Summary
- add server-side VAD tuning settings to `Settings` (env-configurable)
- expose frontend runtime config via `GET /api/v1/config`
- update web client to consume VAD config instead of fixed constants
- add API E2E coverage for config endpoint and update docs/bootstrap script

## Validation
- uv run ruff check .
- uv run mypy voice_triage
- uv run pytest -q
- uv run interrogate --config pyproject.toml voice_triage

Closes #29
